### PR TITLE
Method getTags() in FFmpegFormat and FFmpegStream now returns empty m…

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/probe/FFmpegFormat.java
+++ b/src/main/java/net/bramp/ffmpeg/probe/FFmpegFormat.java
@@ -2,6 +2,8 @@ package net.bramp.ffmpeg.probe;
 
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Collections;
 import java.util.Map;
 
 @SuppressFBWarnings(
@@ -77,6 +79,7 @@ public class FFmpegFormat {
   }
 
   public Map<String, String> getTags() {
+    if(tags == null) return Collections.emptyMap();
     return ImmutableMap.copyOf(tags);
   }
 }

--- a/src/main/java/net/bramp/ffmpeg/probe/FFmpegStream.java
+++ b/src/main/java/net/bramp/ffmpeg/probe/FFmpegStream.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -213,6 +214,7 @@ public class FFmpegStream {
   }
 
   public Map<String, String> getTags() {
+    if(tags == null) return Collections.emptyMap();
     return ImmutableMap.copyOf(tags);
   }
 


### PR DESCRIPTION
…ap when instance variable is null. This caused an exception when serializing.